### PR TITLE
feat: 🎸 adds support for tension, alpha, beta in curves

### DIFF
--- a/packages/core/demo/demo-data/line.ts
+++ b/packages/core/demo/demo-data/line.ts
@@ -55,7 +55,8 @@ export const curvedLineOptions = {
 			}
 		}
 	},
-	curve: "curveNatural",
+	curve: "curveCardinal",
+	curveOptions: { tension: 0 },
 	legendClickable: true,
 	containerResizable: true
 };

--- a/packages/core/src/line-chart.ts
+++ b/packages/core/src/line-chart.ts
@@ -55,7 +55,7 @@ export class LineChart extends BaseAxisChart {
 		this.lineGenerator = line()
 			.x((d, i) => this.x(this.displayData.labels[i]) + margins.left)
 			.y((d: any) => this.y(d))
-			.curve(getD3Curve(this.options.curve) || getD3Curve("curveLinear"));
+			.curve(getD3Curve(this.options.curve, this.options.curveOptions));
 
 		const gLines = this.innerWrap.selectAll("g.lines")
 			.data(this.displayData.datasets)

--- a/packages/core/src/services/curves.ts
+++ b/packages/core/src/services/curves.ts
@@ -40,7 +40,7 @@ const curveTypes = {
 	"curveStepBefore": curveStepBefore
 };
 
-export const getD3Curve = (curveName="curveLinear", curveOptions={}) => {
+export const getD3Curve = (curveName = "curveLinear", curveOptions = {}) => {
 	if (curveTypes[curveName]) {
 		let curve = curveTypes[curveName];
 		Object.keys(curveOptions).forEach(optionName => {

--- a/packages/core/src/services/curves.ts
+++ b/packages/core/src/services/curves.ts
@@ -40,10 +40,15 @@ const curveTypes = {
 	"curveStepBefore": curveStepBefore
 };
 
-export const getD3Curve = curveName => {
+export const getD3Curve = (curveName="curveLinear", curveOptions={}) => {
 	if (curveTypes[curveName]) {
-		return curveTypes[curveName];
+		let curve = curveTypes[curveName];
+		Object.keys(curveOptions).forEach(optionName => {
+			if (curve[optionName]) {
+				curve = curve[optionName](curveOptions[optionName]);
+			}
+		});
+		return curve;
 	}
-
 	return null;
 };


### PR DESCRIPTION
Adds support for D3 curve modification methods like tension, alpha and
beta.

Closes #39

### Updates

- Adds in support for all D3 curve modifying methods (`.tension()`, `.alpha()`, `.beta()`, any any other similar methods).

### Demo screenshot or recording
The demo `curveNatural` has been replaced with the `curveCardinal` with a modified tension (it is visually identical.)

### Review checklist (for reviewers only)

- [x] Demos all features
- [ ] Documented/annotated
- [ ] Matches UI/UX specs
- [x] Meets the [code style guide](https://github.com/IBM/carbon-charts/wiki/Code-style-guide)
- [ ] Accessible
- [ ] Mobile first (responsive)
- [ ] RTL support (bidirectional text)
- [ ] Performant (limited bloat)
