### PR TITLE
chore(core): Optimize threshold colors, remove react-icons as a dependency

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -121,9 +121,9 @@ export const scales = {
 		numberOfTicks: 5,
 		thresholds: {
 			colors: {
-				"danger": "rgba(230, 35, 37, 0.15)",
-				"success": "rgba(254, 213, 0, 0.15)",
-				"warning": "rgba(0, 136, 75, 0.15)"
+				"danger": "rgba(255, 39, 41, 0.1)",
+				"success": "rgba(0, 212, 117, 0.1)",
+				"warning": "rgba(255, 214, 0, 0.1)"
 
 			}
 		}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,8 +24,7 @@
 	"dependencies": {
 		"@carbon/charts": "^0.7.1",
 		"react": "16.0.0",
-		"react-dom": "16.4.2",
-		"react-icons": "2.2.7"
+		"react-dom": "16.4.2"
 	},
 	"devDependencies": {
 		"@storybook/addon-options": "3.4.10",


### PR DESCRIPTION
### Updates
- Optimize colors since transparency makes them look unsaturated, similar to CMYK colors
- Remove `react-icons` from the React package