### PR TITLE
Fix angular build on Travis

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -25,7 +25,7 @@
 		"@angular/common": "6.0.0",
 		"@angular/compiler": "6.0.0",
 		"@angular/compiler-cli": "6.0.0",
-		"@angular/core": "7.1.1",
+		"@angular/core": "6.0.0",
 		"@storybook/addon-actions": "4.0.0-alpha.16",
 		"@storybook/addon-backgrounds": "4.0.0-alpha.16",
 		"@storybook/addon-centered": "4.0.0-alpha.16",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -39,6 +39,7 @@
 		"@storybook/addons": "4.0.0-alpha.16",
 		"@storybook/angular": "4.0.0-alpha.16",
 		"@storybook/storybook-deployer": "2.3.0",
+		"@types/node": "8.5.2",
 		"ng-packagr": "4.4.0",
 		"typescript": "2.7.2"
 	},

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -22,7 +22,10 @@
 		"@carbon/charts": "^0.7.9"
 	},
 	"devDependencies": {
-		"ng-packagr": "4.4.0",
+		"@angular/common": "6.0.0",
+		"@angular/compiler": "6.0.0",
+		"@angular/compiler-cli": "6.0.0",
+		"@angular/core": "7.1.1",
 		"@storybook/addon-actions": "4.0.0-alpha.16",
 		"@storybook/addon-backgrounds": "4.0.0-alpha.16",
 		"@storybook/addon-centered": "4.0.0-alpha.16",
@@ -36,6 +39,7 @@
 		"@storybook/addons": "4.0.0-alpha.16",
 		"@storybook/angular": "4.0.0-alpha.16",
 		"@storybook/storybook-deployer": "2.3.0",
+		"ng-packagr": "4.4.0",
 		"typescript": "2.7.2"
 	},
 	"ngPackage": {

--- a/scripts/build-packages-and-demos.sh
+++ b/scripts/build-packages-and-demos.sh
@@ -24,7 +24,7 @@ rm -rf angular
 mv charts-angular-dist angular
 
 # Build React demos
-cd ../react
+cd react
 npm run build
 npm run build-storybook
 cp -a storybook-dist/. ../../pages/react

--- a/scripts/build-packages-and-demos.sh
+++ b/scripts/build-packages-and-demos.sh
@@ -9,13 +9,13 @@ cd packages/core
 npm run build
 npm run demo:build
 typedoc --out ./demo/bundle/documentation ./src/index.ts
-cp -a demo/bundle/* ../../pages
+cp -a demo/bundle/. ../../pages
 
 # Build Angular demos and copy to `pages` directory
 cd ../angular
 # Build angular demos
 npm run build-storybook
-cp -a storybook-dist/* ../../pages/angular
+cp -a storybook-dist/. ../../pages/angular
 # Build angular bundle for release
 npm run build
 mv dist ../charts-angular-dist


### PR DESCRIPTION
Build seems to be broken because Travis is not able to find `@angular/compiler` inside of `ng-packager`, this PR will add it as a dev-dependency to the `charts-angular` package.